### PR TITLE
Make deployment variables sensitive

### DIFF
--- a/bitbucket/resource_deployment_variable.go
+++ b/bitbucket/resource_deployment_variable.go
@@ -45,8 +45,9 @@ func resourceDeploymentVariable() *schema.Resource {
 				Required: true,
 			},
 			"value": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
 			},
 			"secured": {
 				Type:     schema.TypeBool,


### PR DESCRIPTION
Deployment variables are very frequently used to pass credentials and other sensitive values. Exposing these in the terraform output poses a security problem, specially when running terraform as part of continuous delivery pipelines.

This change makes deployment variable values sensitive, so Terraform hides them on CLI output. 

Example plan output:

```
  # bitbucket_deployment_variable.my_secure_variable will be created
  + resource "bitbucket_deployment_variable" "my_secure_variable" {
      + deployment = (known after apply)
      + id         = (known after apply)
      + key        = "STATE"
      + secured    = true
      + uuid       = (known after apply)
      + value      = (sensitive value)
    }
```

